### PR TITLE
fix: correct Makefile rule phony name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ deploy-docs:
 
 # Development Rules
 
-.PHONY: poetry-dev
+.PHONY: poetry-install-dev
 poetry-install-dev: poetry.lock
 	$(BIN)poetry install
 


### PR DESCRIPTION
.PHONY was referring to an obsolete rule name and causing failure.